### PR TITLE
Change Invoker implementation to use SingleSessionDb.

### DIFF
--- a/unicorn-core/src/main/scala/org/virtuslab/unicorn/utils/Invoker.scala
+++ b/unicorn-core/src/main/scala/org/virtuslab/unicorn/utils/Invoker.scala
@@ -1,7 +1,7 @@
 package org.virtuslab.unicorn.utils
 
 import slick.dbio.DBIOAction
-import slick.driver.JdbcDriver.api._
+import slick.jdbc.JdbcBackend
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
@@ -10,7 +10,10 @@ trait Invoker {
 
   protected val queryTimeout = Duration.Inf
 
-  private[unicorn] def invokeAction[R, S <: slick.dbio.NoStream, E <: slick.dbio.Effect](action: DBIOAction[R, S, E])(implicit session: Session): R = {
-    Await.result(session.database.run(action), queryTimeout)
+  def invokeAction[R, S <: slick.dbio.NoStream, E <: slick.dbio.Effect](action: DBIOAction[R, S, E])(implicit session: JdbcBackend#Session): R = {
+    val db = session.database
+    val singleSessionDb = SingleSessionDb.createFor(session, db.executor)
+    Await.result(singleSessionDb.run(action), queryTimeout)
   }
+
 }

--- a/unicorn-core/src/main/scala/org/virtuslab/unicorn/utils/SingleSessionDb.scala
+++ b/unicorn-core/src/main/scala/org/virtuslab/unicorn/utils/SingleSessionDb.scala
@@ -1,0 +1,54 @@
+package org.virtuslab.unicorn.utils
+
+import java.sql.{ Connection, DatabaseMetaData }
+
+import slick.jdbc.{ JdbcBackend, JdbcDataSource }
+import slick.util.AsyncExecutor
+
+private[utils] object SingleSessionDb {
+
+  def createFor(_session: JdbcBackend#Session, executor: AsyncExecutor): JdbcBackend#Database = {
+
+    def dummyJdbcDataSource = new JdbcDataSource {
+      /*
+        NOTE it's safe because this method is used in slick.jdbc.JdbcBackend.BaseSession, which is created
+        by slick.jdbc.JdbcBackend.DatabaseDef.createSession which we override
+       */
+      def createConnection() = ???
+
+      def close() = ()
+    }
+
+    new JdbcBackend.DatabaseDef(dummyJdbcDataSource, executor) {
+      override def createSession() = {
+        //NOTE path-dependent vs. type-projection type mismatch workaround
+        val _session2: JdbcBackend.SessionDef = _session.asInstanceOf[JdbcBackend.SessionDef]
+
+        new JdbcBackend.SessionDef {
+
+          override def database: JdbcBackend.DatabaseDef = _session2.database
+
+          override def rollback(): Unit = _session2.rollback()
+
+          @volatile
+          override def capabilities: JdbcBackend.DatabaseCapabilities = _session2.capabilities
+
+          override def metaData: DatabaseMetaData = _session2.metaData
+
+          override def close(): Unit = {
+            //NOTE prevent closing the session
+          }
+
+          override def withTransaction[T](f: => T): T = _session2.withTransaction(f)
+
+          override def conn: Connection = _session2.conn
+
+          def startInTransaction: Unit = ()
+          def endInTransaction(f: => Unit): Unit = ()
+        }
+      }
+
+    }
+  }
+
+}


### PR DESCRIPTION
Using SingleSessionDb preserves session and transaction across multiple Invoker calls.
